### PR TITLE
More optimize

### DIFF
--- a/rlogger.go
+++ b/rlogger.go
@@ -55,8 +55,11 @@ func write(w io.Writer, tag, msg []byte) (int, error) {
 	now := uint32(time.Now().Unix())
 	headerLen := HEADER_SIZE + int32(len(tag))
 	buf := Buffs.Get().(*bytes.Buffer)
-	defer Buffs.Put(buf)
-	msgBuf := new(bytes.Buffer)
+	msgBuf := Buffs.Get().(*bytes.Buffer)
+	defer func() {
+		Buffs.Put(msgBuf)
+		Buffs.Put(buf)
+	}()
 
 	offset := 0
 	for {

--- a/rlogger.go
+++ b/rlogger.go
@@ -46,8 +46,15 @@ func write(w io.Writer, tag, msg []byte) (int, error) {
 	buf := new(bytes.Buffer)
 	msgBuf := new(bytes.Buffer)
 
-	for _, line := range bytes.Split(msg, []byte("\n")) {
-		appendPacket(msgBuf, now, line)
+	offset := 0
+	for len(msg[offset:]) > 0 {
+		ret := bytes.IndexByte(msg[offset:], '\n')
+		if ret == -1 {
+			appendPacket(msgBuf, now, msg[offset:])
+			break
+		}
+		appendPacket(msgBuf, now, msg[offset:offset+ret])
+		offset += ret + 1
 	}
 
 	msgLen := int32(msgBuf.Len())

--- a/rlogger.go
+++ b/rlogger.go
@@ -82,7 +82,10 @@ func write(w io.Writer, tag, msg []byte) (int, error) {
 	scratch = append(scratch, tag...)
 
 	buf.Write(scratch)
-	msgBuf.WriteTo(buf)
+	if _, err := msgBuf.WriteTo(buf); err != nil {
+		return 0, err
+	}
+
 	nw, err := buf.WriteTo(w)
 	return int(nw), err
 }

--- a/rlogger.go
+++ b/rlogger.go
@@ -79,9 +79,9 @@ func write(w io.Writer, tag, msg []byte) (int, error) {
 	binary.BigEndian.PutUint16(scratch[2:], uint16(headerLen))
 	binary.BigEndian.PutUint32(scratch[4:], 0)
 	binary.BigEndian.PutUint32(scratch[8:], uint32(pktLen))
-	scratch = append(scratch, tag...)
-
 	buf.Write(scratch)
+	buf.Write(tag)
+
 	if _, err := msgBuf.WriteTo(buf); err != nil {
 		return 0, err
 	}

--- a/rlogger.go
+++ b/rlogger.go
@@ -47,7 +47,7 @@ func write(w io.Writer, tag, msg []byte) (int, error) {
 	msgBuf := new(bytes.Buffer)
 
 	offset := 0
-	for len(msg[offset:]) > 0 {
+	for {
 		ret := bytes.IndexByte(msg[offset:], '\n')
 		if ret == -1 {
 			appendPacket(msgBuf, now, msg[offset:])

--- a/rlogger_test.go
+++ b/rlogger_test.go
@@ -47,7 +47,7 @@ func TestInnerWriteOneLineWithLastCR(t *testing.T) {
 
 	b := buf.Bytes()
 
-	if buf.Len() != 26 {
+	if buf.Len() != 34 {
 		t.Errorf("invalid packet length. len=%v, pkt=%v", buf.Len(), b)
 	}
 
@@ -72,8 +72,13 @@ func TestInnerWriteOneLineWithLastCR(t *testing.T) {
 	}
 
 	// check msg string
-	if string(b[23:]) != "msg" {
-		t.Errorf("invalid message string: %s", b[23:])
+	if string(b[23:26]) != "msg" {
+		t.Errorf("invalid message string: %s", b[23:26])
+	}
+
+	// check msg size (line 2) -> empty
+	if b[33] != 0 {
+		t.Errorf("invalid message size: %v", b[33])
 	}
 }
 
@@ -117,7 +122,7 @@ func TestInnerWriteTwoLine(t *testing.T) {
 		t.Errorf("invalid message size: %v", b[34])
 	}
 
-	// check msg string (line 1)
+	// check msg string (line 2)
 	if string(b[35:]) != "msg2" {
 		t.Errorf("invalid message string: %s", b[35:])
 	}
@@ -129,7 +134,7 @@ func TestInnerWriteTwoLineWithLastCR(t *testing.T) {
 
 	b := buf.Bytes()
 
-	if buf.Len() != 39 {
+	if buf.Len() != 47 {
 		t.Errorf("invalid packet length. len=%v, pkt=%v", buf.Len(), b)
 	}
 
@@ -163,8 +168,14 @@ func TestInnerWriteTwoLineWithLastCR(t *testing.T) {
 		t.Errorf("invalid message size: %v", b[34])
 	}
 
-	// check msg string (line 1)
-	if string(b[35:]) != "msg2" {
-		t.Errorf("invalid message string: %s", b[35:])
+	// check msg string (line 2)
+	if string(b[35:39]) != "msg2" {
+		t.Errorf("invalid message string: %s", b[35:39])
 	}
+
+	// check msg size (line 3) -> empty
+	if b[46] != 0 {
+		t.Errorf("invalid message size: %v", b[46])
+	}
+
 }

--- a/rlogger_test.go
+++ b/rlogger_test.go
@@ -40,3 +40,131 @@ func TestInnerWriteOneLine(t *testing.T) {
 		t.Errorf("invalid message string: %s", b[23:])
 	}
 }
+
+func TestInnerWriteOneLineWithLastCR(t *testing.T) {
+	buf := new(bytes.Buffer)
+	write(buf, []byte("tag"), []byte("msg\n"))
+
+	b := buf.Bytes()
+
+	if buf.Len() != 26 {
+		t.Errorf("invalid packet length. len=%v, pkt=%v", buf.Len(), b)
+	}
+
+	// check version
+	if b[0] != 1 {
+		t.Errorf("invalid version: %v", b[0])
+	}
+
+	// check header size
+	if b[3] != 15 {
+		t.Errorf("invalid header size: %v", b[3])
+	}
+
+	// check tag string
+	if string(b[12:15]) != "tag" {
+		t.Errorf("invalid tag string: %s", b[12:15])
+	}
+
+	// check msg size
+	if b[22] != 3 {
+		t.Errorf("invalid message size: %v", b[22])
+	}
+
+	// check msg string
+	if string(b[23:]) != "msg" {
+		t.Errorf("invalid message string: %s", b[23:])
+	}
+}
+
+func TestInnerWriteTwoLine(t *testing.T) {
+	buf := new(bytes.Buffer)
+	write(buf, []byte("tag"), []byte("msg1\nmsg2"))
+
+	b := buf.Bytes()
+
+	if buf.Len() != 39 {
+		t.Errorf("invalid packet length. len=%v, pkt=%v", buf.Len(), b)
+	}
+
+	// check version
+	if b[0] != 1 {
+		t.Errorf("invalid version: %v", b[0])
+	}
+
+	// check header size
+	if b[3] != 15 {
+		t.Errorf("invalid header size: %v", b[3])
+	}
+
+	// check tag string
+	if string(b[12:15]) != "tag" {
+		t.Errorf("invalid tag string: %s", b[12:15])
+	}
+
+	// check msg size (line 1)
+	if b[22] != 4 {
+		t.Errorf("invalid message size: %v", b[22])
+	}
+
+	// check msg string (line 1)
+	if string(b[23:27]) != "msg1" {
+		t.Errorf("invalid message string: %s", b[23:27])
+	}
+
+	// check msg size (line 2)
+	if b[34] != 4 {
+		t.Errorf("invalid message size: %v", b[34])
+	}
+
+	// check msg string (line 1)
+	if string(b[35:]) != "msg2" {
+		t.Errorf("invalid message string: %s", b[35:])
+	}
+}
+
+func TestInnerWriteTwoLineWithLastCR(t *testing.T) {
+	buf := new(bytes.Buffer)
+	write(buf, []byte("tag"), []byte("msg1\nmsg2\n"))
+
+	b := buf.Bytes()
+
+	if buf.Len() != 39 {
+		t.Errorf("invalid packet length. len=%v, pkt=%v", buf.Len(), b)
+	}
+
+	// check version
+	if b[0] != 1 {
+		t.Errorf("invalid version: %v", b[0])
+	}
+
+	// check header size
+	if b[3] != 15 {
+		t.Errorf("invalid header size: %v", b[3])
+	}
+
+	// check tag string
+	if string(b[12:15]) != "tag" {
+		t.Errorf("invalid tag string: %s", b[12:15])
+	}
+
+	// check msg size (line 1)
+	if b[22] != 4 {
+		t.Errorf("invalid message size: %v", b[22])
+	}
+
+	// check msg string (line 1)
+	if string(b[23:27]) != "msg1" {
+		t.Errorf("invalid message string: %s", b[23:27])
+	}
+
+	// check msg size (line 2)
+	if b[34] != 4 {
+		t.Errorf("invalid message size: %v", b[34])
+	}
+
+	// check msg string (line 1)
+	if string(b[35:]) != "msg2" {
+		t.Errorf("invalid message string: %s", b[35:])
+	}
+}

--- a/rlogger_uds_test.go
+++ b/rlogger_uds_test.go
@@ -1,0 +1,67 @@
+package rlogger
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var SOCKET_PATH string
+
+func TestSimpleWrite(t *testing.T) {
+	tag := []byte("this.is.tag")
+	msg := []byte("hogehoge1")
+	t.Logf("path=%v\n", SOCKET_PATH)
+	r := NewRLogger(SOCKET_PATH)
+	defer r.Close()
+	ret, err := r.Write(tag, msg)
+	if err != nil {
+		t.Errorf("write error: err=%v", err)
+	}
+
+	if ret != 40 {
+		t.Errorf("invalid msg len. len=%v", ret)
+	}
+}
+
+func TestTwoLineWrite(t *testing.T) {
+	tag := []byte("this.is.tag")
+	msg := []byte("hogehoge2\nhogehoge3")
+	r := NewRLogger(SOCKET_PATH)
+	defer r.Close()
+	ret, err := r.Write(tag, msg)
+	if err != nil {
+		t.Errorf("write error: err=%v", err)
+	}
+
+	if ret != 57 {
+		t.Errorf("invalid msg len. len=%v", ret)
+	}
+}
+
+func TestMain(m *testing.M) {
+	dir, err := ioutil.TempDir("", "gorlogger")
+	if err != nil {
+		panic(err)
+	}
+
+	SOCKET_PATH = filepath.Join(dir, "rloggerd.dummy.sock")
+	unixListener, err := net.ListenUnix("unix", &net.UnixAddr{Name: SOCKET_PATH, Net: "unix"})
+	if err != nil {
+		os.RemoveAll(dir)
+		panic(err)
+	}
+
+	go func() {
+		for {
+			unixListener.Accept()
+		}
+	}()
+
+	ret := m.Run()
+	os.RemoveAll(dir)
+
+	os.Exit(ret)
+}


### PR DESCRIPTION
- [x] 1. Use bytes.IndexByte instead of bytes.Split.
- [ ] 2. Unify bytes.Buffer. You can build outer header in-place.
- [x] 3. Cache buffer in RLogger. Guard it with mutex.

see also #2 
